### PR TITLE
Skip tests that hang on MSWin32

### DIFF
--- a/lib/POE/Loop/Tk.pm
+++ b/lib/POE/Loop/Tk.pm
@@ -22,6 +22,9 @@ sub skip_tests {
   if ($test_name eq "k_signals_rerun" and $^O eq "MSWin32") {
     return "This test crashes Perl when run with Tk on $^O";
   }
+  if ($test_name eq 'wheel_tail' and $^O eq "MSWin32") {
+    return "$test_name tests hang on $^O";    
+  }
   return "Tk tests require the Tk module" if do { eval "use Tk"; $@ };
   my $m = eval { Tk::MainWindow->new() };
   if ($@) {

--- a/lib/POE/Loop/Tk.pm
+++ b/lib/POE/Loop/Tk.pm
@@ -13,7 +13,6 @@ use Tk 800.031;
 use 5.00503;
 
 =for poe_tests
-
 sub skip_tests {
   return "Tk needs a DISPLAY (set one today, okay?)" unless (
     (defined $ENV{DISPLAY} and length $ENV{DISPLAY}) or $^O eq "MSWin32"


### PR DESCRIPTION
wheel_tail.pm test hangs on MSWin32 - this test skipped.

Change tested on Perl v5.22.1 built for MSWin32-x86-multi-thread-64int
